### PR TITLE
Minor updates for rocr and rocm-firmware

### DIFF
--- a/pkgs/development/libraries/rocr.nix
+++ b/pkgs/development/libraries/rocr.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchFromGitHub, cmake, elfutils, roct }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.0";
+  version = "1.7.0a";
   name = "rocr-${version}";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
-    rev = "roc-${version}";
-    sha256 = "0k71qdcrskavrk6rdd9hl2rr3p43l5lr401c1yhmhckic19bpaav";
+    # rev = "roc-${version}";
+    rev = "37157bbb3edbec37f4842f6f2f70d250fa5ddd36";
+    sha256 = "0gd5w94hlqr4qq16y91siaikzyn1zgmyly44rvfmm4ns2rs8ddc3";
   };
 
   postUnpack = ''

--- a/pkgs/os-specific/linux/firmware/rocm-compute.nix
+++ b/pkgs/os-specific/linux/firmware/rocm-compute.nix
@@ -4,10 +4,10 @@ stdenv.mkDerivation rec {
   version = "1.7.15";
   name = "rocm-firmware-${version}";
   src = fetchurl {
-    url = "http://repo.radeon.com/rocm/apt/debian/pool/main/c/compute-firmware/compute-firmware_1.7.15_all.deb";
-    sha256 = "09xsvjq5ffijm8jhdncbwhmykc016ciyk024r5z8lb1dnbpbiq4d";
+    url = "http://repo.radeon.com/rocm/apt/debian/pool/main/c/compute-firmware/compute-firmware_1.7.17_all.deb";
+    sha256 = "0bq2mbqbqmvsxf2i06q6lh3r4wfy4ryx7nz5kwryldksbjp4ghw1";
   };
- 
+
   unpackPhase = ''
     ar p $src data.tar.xz | tar -xJ
   '';


### PR DESCRIPTION
- The rocm-firmware version 1.7.15 deb is no longer available for
  download, so we update to 1.7.17

- rocr needs patches to avoid warnings that are treated as errors with
  gcc-7. There is not yet a new release, so we use a specific commit.