### PR TITLE
rocm-1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ to `nixpkgs.overlays` in configuration.nix.
 Add these lines to configuration.nix to enable the ROCm stack:
 ```
   boot.kernelPackages = pkgs.linuxPackages_rocm;
-  hardware.firmware = [ pkgs.rocm_compute_firmware ];
   hardware.opengl.enable = true;
   hardware.opengl.extraPackages = [ pkgs.rocm-opencl-icd ]
 ```

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -45,6 +45,7 @@ with pkgs;
   roct = callPackage ./development/libraries/roct.nix {};
   rocr = callPackage ./development/libraries/rocr {};
   rocminfo = callPackage ./development/tools/rocminfo.nix {};
+  rocm-cmake = callPackage ./development/tools/rocm-cmake.nix {};
 
   # OpenCL stack
   rocm-opencl-runtime = callPackage ./development/libraries/rocm-opencl-runtime.nix {};

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -15,6 +15,12 @@ with pkgs;
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        {
+          # See https://cgit.freedesktop.org/%7Eagd5f/linux/commit/?h=amd-staging-drm-next&id=3f3a7c8259312084291859d3b623db4317365a07
+          patch = ./os-specific/linux/kernel/vboxvideo-ttm.patch;
+          name = "vboxvideo-ttm";
+        }
+
       ]
       ++ lib.optionals ((platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -39,7 +39,7 @@ with pkgs;
   });
 
   # ROCm needs extra firmware
-  rocm_compute_firmware = callPackage ./os-specific/linux/firmware/rocm-compute.nix {};
+  # rocm_compute_firmware = callPackage ./os-specific/linux/firmware/rocm-compute.nix {};
 
   # Userspace ROC stack
   roct = callPackage ./development/libraries/roct.nix {};

--- a/pkgs/development/libraries/rocm-opencl-icd.nix
+++ b/pkgs/development/libraries/rocm-opencl-icd.nix
@@ -1,7 +1,7 @@
 { stdenv, rocm-opencl-runtime, writeText }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.0";
+  version = "1.8.0";
   name = "rocm-opencl-icd";
   src = writeText "amdocl64.icd" "${rocm-opencl-runtime}/lib/libamdocl64.so";
   unpackPhase = ":";

--- a/pkgs/development/libraries/rocm-opencl-runtime.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime.nix
@@ -1,7 +1,7 @@
 { stdenv
 , llvmPackages
 , fetchFromGitHub
-, libGL
+, libGL_driver
 , cmake
 , rocr
 , mesa_noglu
@@ -84,7 +84,8 @@ llvmPackages.stdenv.mkDerivation rec {
     sed -e 's/enable_testing()//' \
         -e 's@add_subdirectory(src/unittest)@@' \
         -i compiler/driver/CMakeLists.txt
-    sed 's,"/etc/OpenCL/vendors/","${libGL.driverLink}/etc/OpenCL/vendors/",g' -i api/opencl/khronos/icd/icd_linux.c
+    sed 's,"/etc/OpenCL/vendors/","${libGL_driver.driverLink}/etc/OpenCL/vendors/",g' -i api/opencl/khronos/icd/icd_linux.c
+    sed 's,amdgcn--amdhsa-amdgizcl,amdgcn-amd-amdhsa-amdgizcl,' -i library/amdgcn/CMakeLists.txt
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/rocm-opencl-runtime.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime.nix
@@ -10,60 +10,64 @@
 }:
 
 llvmPackages.stdenv.mkDerivation rec {
-  version = "1.7.1";
+  version = "1.8.0";
   tag = "roc-${version}";
   name = "rocm-opencl-runtime-${version}";
   srcs =
     [ (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "ROCm-OpenCL-Runtime";
-        rev = "${tag}";
-        sha256 = "00drxc6ql2l346b7v80hajky4b77xdmc175ab06wkx4127cc2gih";
+        # rev = "${tag}";
+        rev = "15fb9b06ecfb8fd87df2578657a49b0a56886245";
+        sha256 = "1mz0jy38lrdha95hdpfb9g4fg9mb0hb6vkpii0x2mabvqi8sa73c";
         name = "ROCm-OpenCL-Runtime-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "ROCm-OpenCL-Driver";
-        rev = "${tag}";
-        sha256 = "02lj2qqxdgfcrki3jn6j8vw1vp9vcd3ds8yxrl8j2amsk474r1dd";
+        # rev = "${tag}";
+        rev = "e0fd00a97a541f5455d583fd5274a9d335165b5e";
+        sha256 = "12lvwpdhv6p82mm7cqnxfgcpd3ddlpa0xb3s1r24ziyfc8qrpayi";
         name = "ROCm-OpenCL-Driver-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "clang";
-        rev = "${tag}";
-        sha256 = "0wnbndds11jmkix39zfn07jnzkd7lj82pkb9pl3ncvdp64rnzxnr";
+        # rev = "${tag}";
+        rev = "daee96b5f4ce15e9c89158c27328000a1a13667a";
+        sha256 = "1dwrjp5qr64p633gpc0q0k9p2mc0ydjjm13ggxvllnf0gyy88xz7";
         name = "clang-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "llvm";
-        rev = "${tag}";
-        sha256 = "1ljkl1r3fbm7x937g69ps7a31a21vsf8pf5jxs8gzqm0xmhh2hrm";
+        # rev = "${tag}";
+        rev = "ccb913df333e220dd05420918d5755040729707b";
+        sha256 = "1ymd5pkx8h55zg5s7x74shn07fbl9x7a3kc6rq1s9caj41bn77gn";
         name = "llvm-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "lld";
-        rev = "${tag}";
-        sha256 = "0wd2qhn2qhbmwhw4qnqb914y29rm249jm1k1ssrx11ps7dn34jmk";
+        # rev = "${tag}";
+        rev = "d18b96ee6ceb4398fc09e8676fe87ad33f5fcd3c";
+        sha256 = "1r1nlk1qhmrf0563x4aqrjjpxhr7dspmar8q411rnril4djwbjz2";
         name = "lld-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "ROCm-Device-Libs";
-        rev = "${tag}";
-        sha256 = "1mqqazb4x4lisgahkix2dgmns4x13wixr30li046vj05inybs06j";
+        # rev = "${tag}";
+        rev = "c0acc0acf1c9852dd6a7313dfe060dee90e2b816";
+        sha256 = "1cm493zs86nn9d51mhacrjpkjl3xc7s466m6g3b639nl5qkqvlwq";
         name = "ROCm-Device-Libs-${tag}-src";
       })
       (fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "OpenCL-ICD-Loader";
-        # rev = "26a3898";
-        # sha256 = "148n8wzf6kp7vjhk6qz5mg4wmrysy8g5z4qmcn8imjgqiinhl05n";
-        rev = "b1155e4b4526f1d52cebebd60ab985dbbc923157";
-        sha256 = "1ym9n0xy9a7lqk845nnyn475kgcnm2c6lz9wlvrb7w94cgpfz707";
-        name = "OpenCL-ICD-Loader-26a3898-src";
+        rev = "b342ff7b7f70a4b3f2cfc53215af8fa20adc3d86";
+        sha256 = "104l33xxras1cadn6xxkas8dl2ss6wi4dlqjqh103ww83g95108x";
+        name = "OpenCL-ICD-Loader-b342ff7-src";
       })
     ];
 
@@ -77,7 +81,7 @@ llvmPackages.stdenv.mkDerivation rec {
     mv lld-${tag}-src ROCm-OpenCL-Runtime-${tag}-src/compiler/llvm/tools/lld
     mkdir ROCm-OpenCL-Runtime-${tag}-src/library/
     mv ROCm-Device-Libs-${tag}-src ROCm-OpenCL-Runtime-${tag}-src/library/amdgcn
-    mv OpenCL-ICD-Loader-26a3898-src ROCm-OpenCL-Runtime-${tag}-src/api/opencl/khronos/icd
+    mv OpenCL-ICD-Loader-b342ff7-src ROCm-OpenCL-Runtime-${tag}-src/api/opencl/khronos/icd
   '';
 
   patchPhase = ''

--- a/pkgs/development/libraries/rocr/default.nix
+++ b/pkgs/development/libraries/rocr/default.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchFromGitHub, cmake, elfutils, roct }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.0";
+  version = "1.7.2";
   name = "rocr-${version}";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
-    # rev = "roc-${version}";
-    # sha256 = "0k71qdcrskavrk6rdd9hl2rr3p43l5lr401c1yhmhckic19bpaav";
 
-    rev = "37157bbb3edbec37f4842f6f2f70d250fa5ddd36";
-    sha256 = "0gd5w94hlqr4qq16y91siaikzyn1zgmyly44rvfmm4ns2rs8ddc3";
+    rev = "e6f4bd6f341f40289e3e5de0c902c1a0ba0f7018";
+    sha256 = "0k71qdcrskavrk6rdd9hl2rr3p43l5lr401c1yhmhckic19bpaav";
   };
 
   postUnpack = ''
     sourceRoot="$sourceRoot/src"
   '';
 
-  # patches = [ ./gcc-7-Wformat-overflow.patch ];
+  prePatch = ''
+    sed 's/sprintf(buff, "%02u", minor);/sprintf(buff, "%02u", minor%100);/' -i core/runtime/hsa.cpp
+  '';
 
   enableParallelBuilding = true;
   buildInputs = [ cmake elfutils ];

--- a/pkgs/development/libraries/rocr/default.nix
+++ b/pkgs/development/libraries/rocr/default.nix
@@ -1,22 +1,18 @@
 { stdenv, fetchFromGitHub, cmake, elfutils, roct }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.2";
+  version = "1.8.0";
   name = "rocr-${version}";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
 
-    rev = "e6f4bd6f341f40289e3e5de0c902c1a0ba0f7018";
-    sha256 = "0k71qdcrskavrk6rdd9hl2rr3p43l5lr401c1yhmhckic19bpaav";
+    rev = "36f9c49c3922634ae045340f2c3c7452a7198e62";
+    sha256 = "1ra03viv7yzmqknz7xhvw9xlcymga7iczwjk3drcbac2jn3ygcgz";
   };
 
   postUnpack = ''
     sourceRoot="$sourceRoot/src"
-  '';
-
-  prePatch = ''
-    sed 's/sprintf(buff, "%02u", minor);/sprintf(buff, "%02u", minor%100);/' -i core/runtime/hsa.cpp
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/roct.nix
+++ b/pkgs/development/libraries/roct.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, pciutils, numactl }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.2";
+  version = "1.8.0";
   name = "roct";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCT-Thunk-Interface";
     rev = "roc-${version}";
-    sha256 = "17bq68ac6mj420q1sdzr5sjvh3r3n3fcjrp8cfm9b7hjhphnxf2x";
+    sha256 = "0yng7jfiq5d8h4qcavndw6frb75wp815ccp91xws61xxh1v96388";
   };
 
   preConfigure = ''

--- a/pkgs/development/libraries/roct.nix
+++ b/pkgs/development/libraries/roct.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, pciutils, numactl }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.1";
+  version = "1.7.2";
   name = "roct";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/development/tools/rocm-cmake.nix
+++ b/pkgs/development/tools/rocm-cmake.nix
@@ -1,0 +1,12 @@
+{ stdenv, fetchFromGitHub, cmake }:
+stdenv.mkDerivation {
+  name = "rocm-cmake";
+  version = "2018-03-30";
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "rocm-cmake";
+    rev = "ec7313aa43de72729c8f66b2e53155e03aa74e20";
+    sha256 = "095x40az48nz28vm2azl7ybbddmp9c2x6nz26qdcl60h8mhqhrqx";
+  };
+  nativeBuildInputs = [ cmake ];
+}

--- a/pkgs/development/tools/rocm-cmake.nix
+++ b/pkgs/development/tools/rocm-cmake.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation {
   name = "rocm-cmake";
-  version = "2018-03-30";
+  version = "2018-05-28";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocm-cmake";
-    rev = "ec7313aa43de72729c8f66b2e53155e03aa74e20";
-    sha256 = "095x40az48nz28vm2azl7ybbddmp9c2x6nz26qdcl60h8mhqhrqx";
+    rev = "3f43e2d493f24abbab4dc189a9ab12cc3ad33baf";
+    sha256 = "0j12jbgi295y37ana86dy8rsys886blr09yd95clwjkrcxv9mgir";
   };
   nativeBuildInputs = [ cmake ];
 }

--- a/pkgs/development/tools/rocminfo.nix
+++ b/pkgs/development/tools/rocminfo.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, rocr, python, rocm-cmake }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.2";
+  version = "1.8.0";
   name = "rocminfo";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocminfo";
-    rev = "c0af93e54b918918e95195292947603ef2eaecc7";
-    sha256 = "0gjsgfk07ddw8scwbq143szl2cbd8zyyhqnznpgfci5la87y6mvv";
+    rev = "8d579bf68e9471422276a1383becf5fe10c95eda";
+    sha256 = "0gjsgfk07ddw8scwbq143szl2cbd8zyyhqnzn123ci5la87y6mvv";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/rocminfo.nix
+++ b/pkgs/development/tools/rocminfo.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     owner = "RadeonOpenCompute";
     repo = "rocminfo";
     rev = "8d579bf68e9471422276a1383becf5fe10c95eda";
-    sha256 = "0gjsgfk07ddw8scwbq143szl2cbd8zyyhqnzn123ci5la87y6mvv";
+    sha256 = "1awrg9crf4cd3zmmrs78l171xg33mby4lxch8ih3085wvbzrrb9p";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/tools/rocminfo.nix
+++ b/pkgs/development/tools/rocminfo.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchFromGitHub, cmake, rocr, python }:
+{ stdenv, fetchFromGitHub, cmake, rocr, python, rocm-cmake }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.0";
+  version = "1.7.2";
   name = "rocminfo";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocminfo";
-    rev = "fd277f3";
-    sha256 = "0q7yl109gm6vn3s0zzldzfazyfkm57i41inxgil0wd7l6v73bs5s";
+    rev = "c0af93e54b918918e95195292947603ef2eaecc7";
+    sha256 = "0gjsgfk07ddw8scwbq143szl2cbd8zyyhqnznpgfci5la87y6mvv";
   };
 
   enableParallelBuilding = true;
-  buildInputs = [ cmake ];
-  cmakeFlags = [ "-DROCM_DIR=${rocr}" ];
+  buildInputs = [ cmake rocm-cmake ];
+  cmakeFlags = [
+    "-DROCR_INC_DIR=${rocr}/include"
+    "-DROCR_LIB_DIR=${rocr}/lib"
+  ];
 
   patchPhase = ''
     sed 's,#!/usr/bin/python,#!${python}/bin/python,' -i rocm_agent_enumerator

--- a/pkgs/os-specific/linux/firmware/rocm-compute.nix
+++ b/pkgs/os-specific/linux/firmware/rocm-compute.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.17";
+  version = "1.7.18";
   name = "rocm-firmware-${version}";
   src = fetchurl {
     url = "http://repo.radeon.com/rocm/apt/debian/pool/main/c/compute-firmware/compute-firmware_${version}_all.deb";
-    sha256 = "0bq2mbqbqmvsxf2i06q6lh3r4wfy4ryx7nz5kwryldksbjp4ghw1";
+    sha256 = "1r1qj49iz1jfwlz7rz0js6zl2sy166gvya3jmgzrcc90q0dg92hy";
   };
 
   unpackPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-4.13-kfd.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13-kfd.nix
@@ -2,7 +2,7 @@
 
 let
   ver = "4.13.0";
-  revision = "kfd-roc-1.7.2";
+  revision = "kfd-roc-1.8.0";
 in
 
 buildLinux (args // rec {
@@ -13,7 +13,7 @@ buildLinux (args // rec {
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCK-Kernel-Driver";
-    rev = "roc-1.7.2";
-    sha256 = "1gv3g3hbq4fsw72bicm17v6nk956qgmblfvwmcylw263jcbphpan";
+    rev = "roc-1.8.0";
+    sha256 = "07nsci09zqx3dzgm4hzdcdnp78gm7gap09is8q9m1hhlrcpnf49d";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.13-kfd.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.13-kfd.nix
@@ -2,7 +2,7 @@
 
 let
   ver = "4.13.0";
-  revision = "kfd-roc-1.7.1";
+  revision = "kfd-roc-1.7.2";
 in
 
 buildLinux (args // rec {
@@ -13,7 +13,7 @@ buildLinux (args // rec {
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCK-Kernel-Driver";
-    rev = "roc-1.7.1";
-    sha256 = "03lkqryy6lsw9vvb8z6w4rbvba8dszqdahd3gfzq6yb1vlih8ax9";
+    rev = "roc-1.7.2";
+    sha256 = "1gv3g3hbq4fsw72bicm17v6nk956qgmblfvwmcylw263jcbphpan";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/vboxvideo-ttm.patch
+++ b/pkgs/os-specific/linux/kernel/vboxvideo-ttm.patch
@@ -1,0 +1,76 @@
+diff -ruN a/drivers/staging/vboxvideo/vbox_ttm.c b/drivers/staging/vboxvideo/vbox_ttm.c
+--- a/drivers/staging/vboxvideo/vbox_ttm.c	2018-05-11 13:18:32.745266997 -0400
++++ b/drivers/staging/vboxvideo/vbox_ttm.c	2018-05-11 13:19:37.960576162 -0400
+@@ -183,13 +183,6 @@
+ {
+ }
+ 
+-static int vbox_bo_move(struct ttm_buffer_object *bo,
+-			bool evict, bool interruptible,
+-			bool no_wait_gpu, struct ttm_mem_reg *new_mem)
+-{
+-	return ttm_bo_move_memcpy(bo, interruptible, no_wait_gpu, new_mem);
+-}
+-
+ static void vbox_ttm_backend_destroy(struct ttm_tt *tt)
+ {
+ 	ttm_tt_fini(tt);
+@@ -237,7 +230,6 @@
+ 	.init_mem_type = vbox_bo_init_mem_type,
+ 	.eviction_valuable = ttm_bo_eviction_valuable,
+ 	.evict_flags = vbox_bo_evict_flags,
+-	.move = vbox_bo_move,
+ 	.verify_access = vbox_bo_verify_access,
+ 	.io_mem_reserve = &vbox_ttm_io_mem_reserve,
+ 	.io_mem_free = &vbox_ttm_io_mem_free,
+@@ -373,6 +365,7 @@
+ 
+ int vbox_bo_pin(struct vbox_bo *bo, u32 pl_flag, u64 *gpu_addr)
+ {
++	struct ttm_operation_ctx ctx = { false, false };
+ 	int i, ret;
+ 
+ 	if (bo->pin_count) {
+@@ -388,7 +381,7 @@
+ 	for (i = 0; i < bo->placement.num_placement; i++)
+ 		bo->placements[i].flags |= TTM_PL_FLAG_NO_EVICT;
+ 
+-	ret = ttm_bo_validate(&bo->bo, &bo->placement, false, false);
++	ret = ttm_bo_validate(&bo->bo, &bo->placement, &ctx);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -402,6 +395,7 @@
+ 
+ int vbox_bo_unpin(struct vbox_bo *bo)
+ {
++	struct ttm_operation_ctx ctx = { false, false };
+ 	int i, ret;
+ 
+ 	if (!bo->pin_count) {
+@@ -415,7 +409,7 @@
+ 	for (i = 0; i < bo->placement.num_placement; i++)
+ 		bo->placements[i].flags &= ~TTM_PL_FLAG_NO_EVICT;
+ 
+-	ret = ttm_bo_validate(&bo->bo, &bo->placement, false, false);
++	ret = ttm_bo_validate(&bo->bo, &bo->placement, &ctx);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -429,6 +423,7 @@
+  */
+ int vbox_bo_push_sysram(struct vbox_bo *bo)
+ {
++	struct ttm_operation_ctx ctx = { false, false };
+ 	int i, ret;
+ 
+ 	if (!bo->pin_count) {
+@@ -447,7 +442,7 @@
+ 	for (i = 0; i < bo->placement.num_placement; i++)
+ 		bo->placements[i].flags |= TTM_PL_FLAG_NO_EVICT;
+ 
+-	ret = ttm_bo_validate(&bo->bo, &bo->placement, false, false);
++	ret = ttm_bo_validate(&bo->bo, &bo->placement, &ctx);
+ 	if (ret) {
+ 		DRM_ERROR("pushing to VRAM failed\n");
+ 		return ret;


### PR DESCRIPTION
Upstream is not consistent about using release tags, so sometime we use a commit hash.