### PR TITLE
ROCm-1.9.1 updates

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -178,4 +178,13 @@ with pkgs;
     inherit (self) rocr rocminfo hcc hip rocm-cmake;
   };
 
+  rocblas-tensile = callPackage ./development/libraries/rocblas/tensile.nix {
+    inherit (python2Packages) buildPythonPackage pyyaml;
+  };
+
+  rocblas = callPackage ./development/libraries/rocblas {
+    inherit (self) rocm-cmake hcc hip rocminfo rocr rocblas-tensile;
+    inherit (python2Packages) python;
+  };
+
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -191,4 +191,11 @@ with pkgs;
     inherit (self) rocm-cmake hcc hip;
   };
 
+  rocrand = callPackage ./development/libraries/rocrand {
+    inherit (self) rocm-cmake rocminfo hcc hip rocr;
+  };
+  rocrand-python-wrappers = callPackage ./development/libraries/rocrand/python.nix {
+    inherit (self) rocr hip rocrand;
+    inherit (python3Packages) buildPythonPackage numpy;
+  };
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -174,4 +174,8 @@ with pkgs;
     useHip = true;
   };
 
+  rocfft = callPackage ./development/libraries/rocfft {
+    inherit (self) rocr rocminfo hcc hip rocm-cmake;
+  };
+
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -160,4 +160,18 @@ with pkgs;
   rocm-bandwidth = callPackage ./tools/rocm-bandwidth {
     inherit (self) roct rocr;
   };
+
+  # MIOpen
+
+  miopengemm = callPackage ./development/libraries/miopengemm {
+    inherit (self) rocm-cmake rocm-opencl-runtime hcc;
+  };
+  miopen-cl = callPackage ./development/libraries/miopen {
+    inherit (self) rocm-cmake rocm-opencl-runtime rocr hcc
+                   clang-ocl miopengemm hip;
+  };
+  miopen-hip = self.miopen-cl.override {
+    useHip = true;
+  };
+
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -206,4 +206,8 @@ with pkgs;
     inherit (self) rocr hip rocrand;
     inherit (python3Packages) buildPythonPackage numpy;
   };
+
+  amdtbasetools = callPackage ./development/libraries/AMDTBaseTools {};
+  amdtoswrappers = callPackage ./development/libraries/AMDTOSWrappers {};
+  cxlactivitylogger = callPackage ./development/libraries/cxlactivitylogger {};
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -187,4 +187,8 @@ with pkgs;
     inherit (python2Packages) python;
   };
 
+  rccl = callPackage ./development/libraries/rccl {
+    inherit (self) rocm-cmake hcc hip;
+  };
+
 }

--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -169,23 +169,6 @@ with pkgs;
     inherit (self) roct rocr;
   };
 
-  # MIOpen
-
-  miopengemm = callPackage ./development/libraries/miopengemm {
-    inherit (self) rocm-cmake rocm-opencl-runtime hcc;
-  };
-  miopen-cl = callPackage ./development/libraries/miopen {
-    inherit (self) rocm-cmake rocm-opencl-runtime rocr hcc
-                   clang-ocl miopengemm hip;
-  };
-  miopen-hip = self.miopen-cl.override {
-    useHip = true;
-  };
-
-  rocfft = callPackage ./development/libraries/rocfft {
-    inherit (self) rocr rocminfo hcc hip rocm-cmake;
-  };
-
   rocblas-tensile = callPackage ./development/libraries/rocblas/tensile.nix {
     inherit (python2Packages) buildPythonPackage pyyaml;
   };
@@ -193,6 +176,23 @@ with pkgs;
   rocblas = callPackage ./development/libraries/rocblas {
     inherit (self) rocm-cmake hcc hip rocminfo rocr rocblas-tensile;
     inherit (python2Packages) python;
+  };
+
+  # MIOpen
+
+  miopengemm = callPackage ./development/libraries/miopengemm {
+    inherit (self) rocm-cmake rocm-opencl-runtime hcc;
+  };
+  miopen-cl = callPackage ./development/libraries/miopen {
+    inherit (self) rocm-cmake rocm-opencl-runtime rocr hcc
+                   clang-ocl miopengemm hip rocblas;
+  };
+  miopen-hip = self.miopen-cl.override {
+    useHip = true;
+  };
+
+  rocfft = callPackage ./development/libraries/rocfft {
+    inherit (self) rocr rocminfo hcc hip rocm-cmake;
   };
 
   rccl = callPackage ./development/libraries/rccl {

--- a/pkgs/development/compilers/clang/default.nix
+++ b/pkgs/development/compilers/clang/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "clang";
-    rev = "3188167ee4cc56e6e7cd699e2afc231f79fefb40";
+    rev = "roc-1.9.1";
     sha256 = "06ph9x757rxy23wfw7lalxp5phqlj53ijbwxf7lasy9kpx2y5xq6";
   };
   nativeBuildInputs = [ cmake python ];

--- a/pkgs/development/compilers/hcc-clang/default.nix
+++ b/pkgs/development/compilers/hcc-clang/default.nix
@@ -1,25 +1,25 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake, python
-, rocr, hcc-llvm, rocminfo }:
+, rocr, hcc-llvm, hcc-lld, rocminfo }:
 stdenv.mkDerivation rec {
   name = "hcc-clang-unwrapped";
   version = "7.0.0";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "hcc-clang-upgrade";
-    rev = "e2b51bfd063e4ccd426b64290bdc1587f2bf855a";
-    sha256 = "09q2rms0xy411a7df9p1a2vs1azhk9j324dk13qb76gy79hmzwls";
+    rev = "37396a09268c7b90c63b91dbd66fe6c3b765bfee";
+    sha256 = "0irkrwgxsdlj8rvwg0q6v1a105pif52kma060771vn3mdxdh2fvf";
   };
   nativeBuildInputs = [ cmake python ];
-  propagatedBuildInputs = [ hcc-llvm ];
+  propagatedBuildInputs = [ hcc-llvm hcc-lld ];
   buildInputs = [ rocr ];
 
   # The patch version is the last two digits of year + week number +
-  # day in the week: date -d "2018-09-06" +%y%U%w
+  # day in the week: date -d "2018-09-19" +%y%U%w
   cmakeFlags = [
     "-DHCC_VERSION_STRING=${version}"
     "-DHCC_VERSION_MAJOR=${stdenv.lib.versions.major version}"
     "-DHCC_VERSION_MINOR=${stdenv.lib.versions.minor version}"
-    "-DHCC_VERSION_PATCH=18354"
+    "-DHCC_VERSION_PATCH=18373"
   ];
 
   patchPhase = ''

--- a/pkgs/development/compilers/hcc-clang/default.nix
+++ b/pkgs/development/compilers/hcc-clang/default.nix
@@ -21,9 +21,11 @@ stdenv.mkDerivation rec {
     "-DHCC_VERSION_MINOR=${stdenv.lib.versions.minor version}"
     "-DHCC_VERSION_PATCH=18373"
   ];
+  patches = [ ./flatwgs-not-null.patch ];
 
-  patchPhase = ''
+  preConfigure = ''
     sed 's,\(const char\* tmp = \)std::getenv("ROCM_ROOT");,\1"${rocminfo}";,' -i ./lib/Driver/ToolChains/Hcc.cpp
+    sed 's/FDecl->getName()/FDecl->getNameAsString()/' -i lib/Sema/SemaTemplateInstantiateDecl.cpp
   '';
 
   hardeningDisable = ["all"];

--- a/pkgs/development/compilers/hcc-clang/flatwgs-not-null.patch
+++ b/pkgs/development/compilers/hcc-clang/flatwgs-not-null.patch
@@ -1,0 +1,23 @@
+diff -ruN orig/lib/CodeGen/TargetInfo.cpp patched/lib/CodeGen/TargetInfo.cpp
+--- orig/lib/CodeGen/TargetInfo.cpp	1969-12-31 19:00:01.000000000 -0500
++++ patched/lib/CodeGen/TargetInfo.cpp	2018-10-23 15:33:47.640818323 -0400
+@@ -7683,11 +7683,15 @@
+ 
+   const auto *FlatWGS = FD->getAttr<AMDGPUFlatWorkGroupSizeAttr>();
+   if (ReqdWGS || FlatWGS) {
+-    llvm::APSInt min = getConstexprInt(FlatWGS->getMin(), FD->getASTContext());
+-    llvm::APSInt max = getConstexprInt(FlatWGS->getMax(), FD->getASTContext());
++    unsigned Min = 0, Max = 0;
++    if (FlatWGS != nullptr) {
++      llvm::APSInt min = getConstexprInt(FlatWGS->getMin(), FD->getASTContext());
++      llvm::APSInt max = getConstexprInt(FlatWGS->getMax(), FD->getASTContext());
+ 
+-    unsigned Min = min.getZExtValue();
+-    unsigned Max = std::max(min, max).getZExtValue();
++      Min = min.getZExtValue();
++      Max = std::max(min, max).getZExtValue();  
++    }
++    
+     if (ReqdWGS && Min == 0 && Max == 0)
+       Min = Max = ReqdWGS->getXDim() * ReqdWGS->getYDim() * ReqdWGS->getZDim();
+ 

--- a/pkgs/development/compilers/hcc-lld/default.nix
+++ b/pkgs/development/compilers/hcc-lld/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, cmake, fetchFromGitHub, libxml2, hcc-llvm }:
+stdenv.mkDerivation {
+  name = "hcc-lld";
+  version = "2018-06-11";
+  src = fetchFromGitHub {
+    owner = "RadeonOpenCompute";
+    repo = "lld";
+    rev = "38dff40c22de0f5ed9a88eb5311476d55e05f6a8";
+    sha256 = "0cbjll23d40fvkwvg80880svv29yapsb96m5ki3digd5wljddb65";
+  };
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ hcc-llvm libxml2 ];
+
+  outputs = [ "out" "dev" ];
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput include "$dev"
+    moveToOutput lib "$dev"
+  '';
+}

--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation {
     sed -e 's,$ROCM_AGENT_ENUM = "''${ROCM_PATH}/bin/rocm_agent_enumerator";,$ROCM_AGENT_ENUM = "${rocminfo}/bin/rocm_agent_enumerator";,' \
         -e 's,^\([[:space:]]*$HSA_PATH=\).*$,\1"${rocr}";,' \
         -e 's,^\([[:space:]]*$HCC_HOME=\).*$,\1"${hcc}";,' \
+        -e 's,\([[:space:]]*$HOST_OSNAME=\).*,\1"nixos";,' \
+        -e 's,\([[:space:]]*$HOST_OSVER=\).*,\1"${stdenv.lib.version}";,' \
         -i bin/hipcc
     sed -i 's,\([[:space:]]*$HCC_HOME=\).*$,\1"${hcc}";,' -i bin/hipconfig
 

--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, perl, writeText
 , hcc, roct, rocr, rocminfo }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "hip";
-  version = "1.9.0";
+  version = "1.9.1";
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "HIP";
-    rev = "bbabadd9784503e7a0f885a6883084a95d6df199";
-    sha256 = "0rr91524cg5arbxcxs9mhl4ampl2shvswwbqskq7821rhzqcxp8n";
+    rev = "roc-${version}";
+    sha256 = "1y9zm9lh81gr18yrz9q6i247f5sn74yn6dnrz4k7v61swbg7i8rm";
   };
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ hcc roct rocminfo ];

--- a/pkgs/development/libraries/AMDTBaseTools/default.nix
+++ b/pkgs/development/libraries/AMDTBaseTools/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, cmake }:
+let srcs = {
+  utf8cpp = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-lib-ext-utf8cpp";
+    rev = "53048f8f7eb69f315a957637d0422845c6652fe5";
+    sha256 = "1nmj6l6zdb5v0xp3dshd51kvzsgwb0dcixbx3116zvgq6bk8axbi";
+  };
+}; in
+stdenv.mkDerivation {
+  name = "AMDTBaseTools";
+  version = "";
+  src = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-AMDTBaseTools";
+    rev = "8ab67ae9ab00cb13d6c9867dbc4fe80bd2776045";
+    sha256 = "0w67ip40z5s5kci97xhxcvjrj9l0qsw5hh983g6hpgx2873i8v1i";
+  };
+  nativeBuildInputs = [ cmake ];
+  postUnpack = ''
+    ln -s $PWD/$sourceRoot $PWD/$sourceRoot/AMDTBaseTools
+    mkdir -p $sourceRoot/Lib/Ext
+    ln -s ${srcs.utf8cpp} $sourceRoot/Lib/Ext/utf8cpp
+  '';
+  patchPhase = ''
+    sed -e 's,\(include_directories("''${PROJECT_SOURCE_DIR}\)/../"),\1"),' \
+        -e 's,\(add_library(AMDTBaseTools\) STATIC,\1 SHARED,' \
+        -i CMakeLists.txt
+    echo 'set_target_properties(AMDTBaseTools PROPERTIES PUBLIC_HEADER "Include/AMDTDefinitions.h;Include/gtAlgorithms.h;Include/gtASCIIString.h;Include/gtASCIIStringTokenizer.h;Include/gtAssert.h;Include/gtAutoPtr.h;Include/gtDenseIndexSet.h;Include/gtFlatMap.h;Include/gtFlatSet.h;Include/gtFlatTree.h;Include/gtFragmentedVector.h;Include/gtGRBaseToolsDLLBuild.h;Include/gtHashMap.h;Include/gtHashSet.h;Include/gtIAllocationFailureObserver.h;Include/gtIAssertionFailureHandler.h;Include/gtIgnoreBoostCompilerWarnings.h;Include/gtIgnoreCompilerWarnings.h;Include/gtList.h;Include/gtMap.h;Include/gtPtrVector.h;Include/gtQueue.h;Include/gtRedBlackTree.h;Include/gtSet.h;Include/gtSmallSList.h;Include/gtStack.h;Include/gtStringConstants.h;Include/gtString.h;Include/gtStringTokenizer.h;Include/gtVector.h")' >> CMakeLists.txt
+    echo "install(TARGETS AMDTBaseTools LIBRARY DESTINATION $out/lib PUBLIC_HEADER DESTINATION $out/include/AMDTBaseTools/Include)" >> CMakeLists.txt
+  '';
+  cmakeFlags = [
+    "-DCMAKE_CXX_FLAGS=-DAMDT_PUBLIC"
+  ];
+}

--- a/pkgs/development/libraries/AMDTOSWrappers/default.nix
+++ b/pkgs/development/libraries/AMDTOSWrappers/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, cmake, tinyxml2, zlib, amdtbasetools }:
+let srcs = {
+  versioninfo = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-VersionInfo";
+    rev = "1f66f52bf900821e002578f06ed78d53faf2268d";
+    sha256 = "1rfm39qbj75f7fnaqd2vv1l22z5xcn2x9lkhqz00r6fwg6vx4kiz";
+  };
+  miniz = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-Miniz";
+    rev = "a958cde31565769681aa3d7934c3d38c52940f4e";
+    sha256 = "189rry9r72baxjavhinz9dwlbyykn9a76a1mikhcph118dw2i4aj";
+  };
+}; in
+stdenv.mkDerivation {
+  name = "AMDTOSWrappers";
+  version = "2018-10-10";
+  src = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-AMDTOSWrappers";
+    rev = "551f171f3a13f69f937a6918bb36a8012a8ef9d2";
+    sha256 = "0bhdhaa4v839q7ag5c9h47s8wb2dvh6gaxz6mkj6nln019jfgzcv";
+  };
+  postUnpack = ''
+    ln -s $PWD/$sourceRoot $PWD/$sourceRoot/AMDTOSWrappers
+    ln -s ${srcs.versioninfo} $PWD/$sourceRoot/VersionInfo
+    ln -s ${srcs.miniz} $PWD/$sourceRoot/Miniz
+  '';
+  cmakeFlags = [
+    "-DCMAKE_CXX_FLAGS=-DAMDT_PUBLIC"
+  ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ tinyxml2 zlib amdtbasetools ];
+  patchPhase = ''
+    sed '/#define MINIZ_HEADER_FILE_ONLY/d' -i src/common/osDirectorySerializer.cpp
+    sed -e 's,\(include_directories("''${PROJECT_SOURCE_DIR}\)/../"),\1"),' \
+        -e 's,\(include_directories("''${PROJECT_SOURCE_DIR}\)/../Miniz"),\1/Miniz"),' \
+        -e 's,\(add_library(AMDTOSWrappers\) STATIC,\1 SHARED,' \
+        -i CMakeLists.txt
+    echo 'add_library(tinyxml SHARED IMPORTED)' >> CMakeLists.txt
+    echo 'set_target_properties(tinyxml PROPERTIES IMPORTED_LOCATION ${tinyxml2}/lib/libtinyxml.so)' >> CMakeLists.txt
+    echo 'add_library(zlib SHARED IMPORTED)' >> CMakeLists.txt
+    echo 'set_target_properties(zlib PROPERTIES IMPORTED_LOCATION ${zlib}/lib/libz.so)' >> CMakeLists.txt
+    echo 'target_link_libraries(AMDTOSWrappers tinyxml zlib)' >> CMakeLists.txt
+    echo 'set_target_properties(AMDTOSWrappers PROPERTIES PUBLIC_HEADER "Include/osApplication.h;Include/osAtomic.h;Include/osBugReporter.h;Include/osBundle.h;Include/osCallsStackReader.h;Include/osCallStackFrame.h;Include/osCallStack.h;Include/osCGIInputDataReader.h;Include/osChannelEncryptor.h;Include/osChannel.h;Include/osChannelOperators.h;Include/osCommunicationDebugManager.h;Include/osCommunicationDebugThread.h;Include/osCondition.h;Include/osConsole.h;Include/osCpuid.h;Include/osCPUSampledData.h;Include/osCriticalSection.h;Include/osCriticalSectionLocker.h;Include/osDaemon.h;Include/osDebuggingFunctions.h;Include/osDebugLog.h;Include/osDebugLogParser.h;Include/osDesktop.h;Include/osDirectory.h;Include/osDirectorySerializer.h;Include/osDNSQueryThread.h;Include/osDoubleBufferQueue.h;Include/osEnvironmentVariable.h;Include/osExceptionReason.h;Include/osFile.h;Include/osFileLauncher.h;Include/osFilePathByLastAccessDateCompareFunctor.h;Include/osFilePath.h;Include/osFilePermissions.h;Include/osGeneralFunctions.h;Include/osHTTPClient.h;Include/osIOKitForiPhoneDevice.h;Include/osKeyboardListener.h;Include/osLinuxProcFileSystemReader.h;Include/osMachine.h;Include/osMacSystemResourcesSampler.h;Include/osMessageBox.h;Include/osModuleArchitecture.h;Include/osModule.h;Include/osMutex.h;Include/osMutexLocker.h;Include/osNetworkAdapter.h;Include/osNULLSocket.h;Include/osOSDefinitions.h;Include/osOSWrappersDLLBuild.h;Include/osOutOfMemoryHandling.h;Include/osPhysicalMemorySampledData.h;Include/osPipeExecutor.h;Include/osPipeSocketClient.h;Include/osPipeSocket.h;Include/osPipeSocketServer.h;Include/osPortAddress.h;Include/osProcess.h;Include/osProcessSharedFile.h;Include/osProductVersion.h;Include/osRawMemoryBuffer.h;Include/osRawMemoryStream.h;Include/osReadWriteLock.h;Include/osSettingsFileHandler.h;Include/osSharedMemorySocketClient.h;Include/osSharedMemorySocket.h;Include/osSharedMemorySocketServer.h;Include/osSingleApplicationInstance.h;Include/osSocket.h;Include/osStdLibIncludes.h;Include/osStopWatch.h;Include/osStream.h;Include/osStringConstants.h;Include/osSynchronizationObject.h;Include/osSynchronizationObjectLocker.h;Include/osSynchronizedQueue.h;Include/osSystemError.h;Include/osSystemResourcesDataSampler.h;Include/osTCPSocketClient.h;Include/osTCPSocket.h;Include/osTCPSocketServerConnectionHandler.h;Include/osTCPSocketServer.h;Include/osThread.h;Include/osThreadLocalData.h;Include/osTime.h;Include/osTimeInterval.h;Include/osTimer.h;Include/osToAndFromString.h;Include/osTransferableObjectCreator.h;Include/osTransferableObjectCreatorsBase.h;Include/osTransferableObjectCreatorsManager.h;Include/osTransferableObject.h;Include/osTransferableObjectType.h;Include/osUnhandledExceptionHandler.h;Include/osUser.h;Include/osWin32CallStackReader.h;Include/osWin32DebugInfoReader.h;Include/osWin32DebugSymbolsManager.h;Include/osWin32Functions.h;Include/osWrappersInitFunc.h")' >> CMakeLists.txt
+    echo "install(TARGETS AMDTOSWrappers LIBRARY DESTINATION $out/lib PUBLIC_HEADER DESTINATION $out/include/AMDTOSWrappers/Include)" >> CMakeLists.txt
+  '';
+}

--- a/pkgs/development/libraries/cxlactivitylogger/default.nix
+++ b/pkgs/development/libraries/cxlactivitylogger/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, scons, amdtbasetools, amdtoswrappers }:
+let srcs = {
+  logger = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-AMDTActivityLogger";
+    rev = "97621e32a32c068e42304f2115043df51bc4824f";
+    sha256 = "0022zm3iz6gfdapn5bmi4yj4zh20hgrvxjbk8f6mr12b2s1z1bxw";
+  };
+  common = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-SCons";
+    rev = "e9c301ef944a3449a316fc4bf109c1cae2a758d8";
+    sha256 = "0mc2bm9n4ixvmwycf5pv5hz8ik7v8lhnfg9g34by1l4kvxswzbm3";
+  };
+  tsingleton = fetchFromGitHub {
+    owner = "GPUOpen-Tools";
+    repo = "common-src-TSingleton";
+    rev = "ebde730c07eac1c1da7f486d65517b93e1550edb";
+    sha256 = "1fz6xdml64p7n9ig3qiyjrr58ylmyx4m7bci7g1nv2s0mx3cq02k";
+  };
+}; in
+stdenv.mkDerivation rec {
+  name = "cxlactivitylogger";
+  version = "2018-10-08";
+  src = srcs.logger;
+  nativeBuildInputs = [ scons ];
+  buildInputs = [ amdtbasetools amdtoswrappers ];
+  postUnpack = ''
+    cp -n ${srcs.common}/* $sourceRoot
+    cp -n ${srcs.tsingleton}/* $sourceRoot
+  '';
+  buildCommand = ''
+    unpackPhase
+    cd $sourceRoot
+    $CXX AMDTActivityLogger.cpp AMDTActivityLoggerProfileControl.cpp AMDTActivityLoggerTimeStamp.cpp -lAMDTOSWrappers -lAMDTBaseTools -std=c++11 -fno-strict-aliasing -D_LINUX -DAMDT_BUILD_SUFFIX= -DAMDT_DEBUG_SUFFIX= -DAMDT_PUBLIC -DNDEBUG -shared -o libCXLActivityLogger.so
+    mkdir -p $out/lib $out/include
+    cp libCXLActivityLogger.so $out/lib
+    cp CXLActivityLogger.h $out/include
+  '';
+}

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, half, openssl, boost
-, rocm-cmake, rocm-opencl-runtime, rocr, hcc, clang-ocl, miopengemm
+, rocm-cmake, rocm-opencl-runtime, rocr, hcc, clang-ocl, miopengemm, rocblas
 , useHip ? false, hip }:
 assert useHip -> hip != null;
 stdenv.mkDerivation rec {
@@ -12,23 +12,28 @@ stdenv.mkDerivation rec {
     sha256 = "172qckpfihwvpxi1adzprn7ngprsdy8q8v3zlcdmlfi0bjisg3x7";
   };
   nativeBuildInputs = [ cmake pkgconfig rocm-cmake ];
-  buildInputs = [ rocr half openssl boost ]
+  buildInputs = [ rocr half openssl boost rocblas miopengemm ]
     ++ (if useHip then [ hcc hip ] else [rocm-opencl-runtime clang-ocl]);
 
   cmakeFlags = [
     "-DCMAKE_PREFIX_PATH=${hcc};${hip};${clang-ocl}"
     "-DMIOPEN_AMDGCN_ASSEMBLER_PATH=${hcc}/bin"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DMIOPEN_USE_ROCBLAS=ON"
   ] ++ (if useHip
   then [ "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+         "-DCMAKE_C_COMPILER=${hcc}/bin/clang"
          "-DMIOPEN_BACKEND=HIP"
-         "-DENABLE_HIP_WORKAROUNDS=YES" ]
+         "-DENABLE_HIP_WORKAROUNDS=NO" ]
   else [ "-DMIOPEN_BACKEND=OpenCL"
          "-DOPENCL_INCLUDE_DIRS=${rocm-opencl-runtime}/include/opencl2.2"
          "-DOPENCL_LIB_DIRS=${rocm-opencl-runtime}/lib"
   ]);
   patchPhase = ''
     sed -e 's,cmake_minimum_required( VERSION 2.8.12 ),cmake_minimum_required( VERSION 3.10 ),' \
+        -e 's,\(set( MIOPEN_INSTALL_DIR\).*,\1 ''${CMAKE_INSTALL_PREFIX}),' \
         -i CMakeLists.txt
+    sed 's/return record;/return std::move(record);/' -i src/include/miopen/db.hpp
+    sed 's/return record;/return std::move(record);/' -i src/db.cpp
   '';
 }

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, half, openssl, boost
+, rocm-cmake, rocm-opencl-runtime, rocr, hcc, clang-ocl, miopengemm
+, useHip ? false, hip }:
+assert useHip -> hip != null;
+stdenv.mkDerivation rec {
+  name = "miopen";
+  version = "1.5.0";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "MIOpen";
+    rev = version;
+    sha256 = "172qckpfihwvpxi1adzprn7ngprsdy8q8v3zlcdmlfi0bjisg3x7";
+  };
+  nativeBuildInputs = [ cmake pkgconfig rocm-cmake ];
+  buildInputs = [ rocr half openssl boost ]
+    ++ (if useHip then [ hcc hip ] else [rocm-opencl-runtime clang-ocl]);
+
+  cmakeFlags = [
+    "-DCMAKE_PREFIX_PATH=${hcc};${hip};${clang-ocl}"
+    "-DMIOPEN_AMDGCN_ASSEMBLER_PATH=${hcc}/bin"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ (if useHip
+  then [ "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+         "-DMIOPEN_BACKEND=HIP"
+         "-DENABLE_HIP_WORKAROUNDS=YES" ]
+  else [ "-DMIOPEN_BACKEND=OpenCL"
+         "-DOPENCL_INCLUDE_DIRS=${rocm-opencl-runtime}/include/opencl2.2"
+         "-DOPENCL_LIB_DIRS=${rocm-opencl-runtime}/lib"
+  ]);
+  patchPhase = ''
+    sed -e 's,cmake_minimum_required( VERSION 2.8.12 ),cmake_minimum_required( VERSION 3.10 ),' \
+        -i CMakeLists.txt
+  '';
+}

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub, cmake
+, rocm-cmake, rocm-opencl-runtime, hcc }:
+stdenv.mkDerivation {
+  name = "miopengemm";
+  version = "2018-04-03";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "MIOpenGEMM";
+    rev = "9547fb9e8499a5a9f16da83b1e6b749de82dd9fb";
+    sha256 = "0n02kd1687a8m3ilfrkpdxswnh83mcm4i48gf6irw7dzgdgyxczy";
+  };
+  nativeBuildInputs = [ cmake rocm-cmake ];
+  buildInputs = [ rocm-opencl-runtime ];
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+    "-DOPENCL_INCLUDE_DIRS=${rocm-opencl-runtime}/include/opencl2.2"
+    "-DOPENCL_LIBRARIES=${rocm-opencl-runtime}/lib/libOpenCL.so"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+}

--- a/pkgs/development/libraries/rccl/default.nix
+++ b/pkgs/development/libraries/rccl/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchFromGitHub, cmake, rocm-cmake, hcc, hip }:
+stdenv.mkDerivation {
+  name = "rccl";
+  version = "2018-10-04";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rccl";
+    rev = "3e6853a56cee00b2c4470f6c8c283a2c4536daa1";
+    sha256 = "06cyj7j03c0nlsdn7lscrr4k1956w2zy07dym8dqkv5wn9i6hi3j";
+  };
+  nativeBuildInputs = [ cmake hcc hip ];
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DROCM_DIR=${rocm-cmake}/share/rocm/cmake"
+  ];
+}

--- a/pkgs/development/libraries/rccl/default.nix
+++ b/pkgs/development/libraries/rccl/default.nix
@@ -1,17 +1,40 @@
-{ stdenv, fetchFromGitHub, cmake, rocm-cmake, hcc, hip }:
-stdenv.mkDerivation {
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig
+, rocm-cmake, hcc, hip
+, doCheck ? false, gtest }:
+stdenv.mkDerivation rec {
   name = "rccl";
-  version = "2018-10-04";
+  version = "0.6.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "rccl";
-    rev = "3e6853a56cee00b2c4470f6c8c283a2c4536daa1";
-    sha256 = "06cyj7j03c0nlsdn7lscrr4k1956w2zy07dym8dqkv5wn9i6hi3j";
+    # rev = version;
+    rev = "0b7f928e774b4847ee39ab9131907649c055ad69";
+    sha256 = "0j4bfd42wvxhvviyawy9nn7s8qc7046mnci90i4b7yy86mrxzp15";
   };
-  nativeBuildInputs = [ cmake hcc hip ];
+  patches = [(fetchpatch {
+    name = "optional-tests.patch";
+    url = "https://github.com/ROCmSoftwarePlatform/rccl/commit/b51b758bdfb1d0d43ff1c2466a88ef522e26f336.patch";
+    sha256 = "0dwfb2g4ncnsk7cs5yhfl50m3iizmadrgs8p4pqxhz43m6r32nb9";
+  })];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ hcc hip ];
   cmakeFlags = [
     "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DROCM_DIR=${rocm-cmake}/share/rocm/cmake"
+    "-DBUILD_DOC=OFF"
   ];
+  inherit doCheck;
+
+  # NOTE: This works in a nix-shell, but not with nix-build due to user groups
+  checkPhase = stdenv.lib.optionalString doCheck ''
+    ln -s $(dirname `pwd`)/inc $(dirname `pwd`)/include
+    export NIX_LDFLAGS="$NIX_LDFLAGS -L$PWD -L${gtest}/lib"
+    export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+    mkdir tests
+    cd tests
+    cmake ../../tests -DCMAKE_CXX_COMPILER=${hcc}/bin/hcc -DCMAKE_C_COMPILER=${hcc}/bin/clang -DROCM_DIR=${rocm-cmake}/share/rocm/cmake -DGOOGLETEST_DIR=${gtest} -DRCCL_DIR=$(dirname $(dirname `pwd`))
+    make -j $NIX_BUILD_CORES
+    make test
+  '';
 }

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -9,12 +9,12 @@ let pyenv = python.withPackages (ps:
 assert useTensile -> rocblas-tensile != null;
 stdenv.mkDerivation rec {
   name = "rocblas";
-  version = "14.2.5";
+  version = "14.3.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "rocBLAS";
     rev = "v${version}";
-    sha256 = "0k3pq5yqp8yfwfc8m41h38nqc74ck2ry6p2bcch7n115kjnadn3r";
+    sha256 = "12w33bjm96cv44g06zwc2yk8a8a9d16rc6pxc8psrn2xv903i8ah";
   };
   nativeBuildInputs = [ cmake rocm-cmake pkgconfig python ];
   buildInputs = [ libunwind pyenv hcc hip rocminfo rocr ]

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libunwind, python
+, rocr, rocminfo, hcc, hip, rocm-cmake
+, doCheck ? false
+# Tensile slows the build a lot, but can produce a faster rocBLAS
+, useTensile ? true, rocblas-tensile ? null
+, gfortran, liblapack, boost, gtest }:
+let pyenv = python.withPackages (ps:
+               with ps; [pyyaml pip wheel setuptools virtualenv]); in
+assert useTensile -> rocblas-tensile != null;
+stdenv.mkDerivation rec {
+  name = "rocblas";
+  version = "14.2.5";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocBLAS";
+    rev = "v${version}";
+    sha256 = "0k3pq5yqp8yfwfc8m41h38nqc74ck2ry6p2bcch7n115kjnadn3r";
+  };
+  nativeBuildInputs = [ cmake rocm-cmake pkgconfig python ];
+  buildInputs = [ libunwind pyenv hcc hip rocminfo rocr ]
+    ++ stdenv.lib.optionals doCheck [ gfortran boost gtest liblapack ];
+  preConfigure = ''
+    export CXX=${hcc}/bin/hcc
+  '';
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DBUILD_WITH_TENSILE=${if useTensile then "ON" else "OFF"}"
+  ] ++ stdenv.lib.optionals doCheck [
+    "-DBUILD_CLIENTS_SAMPLES=YES"
+    "-DBUILD_CLIENTS_TESTS=YES"
+    "-DBUILD_CLIENTS_BENCHMARKS=YES"
+  ] ++ stdenv.lib.optionals useTensile [
+    "-DVIRTUALENV_HOME_DIR=${rocblas-tensile}"
+    "-DTensile_TEST_LOCAL_PATH=${rocblas-tensile}"
+    "-DTensile_ROOT=${rocblas-tensile}/lib/python${python.majorVersion}/site-packages"
+    "-DTensile_LOGIC=hip_lite"
+  ];
+
+  patchPhase = ''
+    sed -e '/include(virtualenv)/d' \
+        -e '/virtualenv_install.*/d' \
+        -e 's|/opt/rocm/hcc|${hcc}|' \
+        -e 's|/opt/rocm/hip|${hip}|' \
+        -i CMakeLists.txt
+  '';
+}

--- a/pkgs/development/libraries/rocblas/tensile.nix
+++ b/pkgs/development/libraries/rocblas/tensile.nix
@@ -1,12 +1,12 @@
 { fetchFromGitHub, buildPythonPackage, pyyaml }:
 buildPythonPackage rec {
   pname = "Tensile";
-  version = "4.5.1";
+  version = "4.6.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "Tensile";
     rev = "v${version}";
-    sha256 = "1sbr04jk000gv0afj6vyddxm2n9frahs2rmw3jsx8j2gkfvkqhih";
+    sha256 = "048sji67gm10z7nj3sssjvp3k2ri0xnl7awh2n92iscf4zk6c9nr";
   };
   buildInputs = [ pyyaml ];
 }

--- a/pkgs/development/libraries/rocblas/tensile.nix
+++ b/pkgs/development/libraries/rocblas/tensile.nix
@@ -1,0 +1,12 @@
+{ fetchFromGitHub, buildPythonPackage, pyyaml }:
+buildPythonPackage rec {
+  pname = "Tensile";
+  version = "4.5.1";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "Tensile";
+    rev = "v${version}";
+    sha256 = "1sbr04jk000gv0afj6vyddxm2n9frahs2rmw3jsx8j2gkfvkqhih";
+  };
+  buildInputs = [ pyyaml ];
+}

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, rocr, rocminfo, hcc, hip, rocm-cmake
+, doCheck ? false
+, boost, gtest, fftw, fftwFloat }:
+stdenv.mkDerivation rec {
+  name = "rocFFT";
+  version = "2018-10-05";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocFFT";
+    rev = "e32b45a42a8cb16253130bb372ee557cd9e5443e";
+    sha256 = "0mg3g4wn32akpvyvs4wk9g6lrd8qp7r8g3pih2709s5a2qwwgg5z";
+  };
+
+  # Building this package is very RAM intensive: individual clang
+  # processes use over 6GB of RAM.
+  enableParallelBuilding = false;
+
+  nativeBuildInputs = [ cmake rocm-cmake pkgconfig ];
+  buildInputs = [ hcc hip rocr ]
+    ++ stdenv.lib.optionals doCheck [ boost gtest fftwFloat fftw ];
+  cmakeFlags = [
+    "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+    "-DHSA_HEADER=${rocr}/include"
+    "-DHSA_LIBRARY=${rocr}/lib/libhsa-runtime64.so"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ stdenv.lib.optionals doCheck [
+    "-DBUILD_CLIENTS_TESTS=ON"
+    "-DBUILD_CLIENTS_BENCHMARKS=ON"
+  ];
+}

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -4,12 +4,12 @@
 , boost, gtest, fftw, fftwFloat }:
 stdenv.mkDerivation rec {
   name = "rocFFT";
-  version = "2018-10-05";
+  version = "2018-10-11";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "rocFFT";
-    rev = "e32b45a42a8cb16253130bb372ee557cd9e5443e";
-    sha256 = "0mg3g4wn32akpvyvs4wk9g6lrd8qp7r8g3pih2709s5a2qwwgg5z";
+    rev = "29bb4908f033f3fb96339c5f3efb972f65c148ca";
+    sha256 = "0napb6zhb7bj7jwrvai2x96vn1b37zn3hbvkfgamz47gbiwlxan9";
   };
 
   # Building this package is very RAM intensive: individual clang

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake
 , rocm-llvm, rocm-lld, rocm-clang, rocr }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "rocm-device-libs";
-  version = "1.9.0";
+  version = "1.9.1";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-Device-Libs";
-    rev = "e0162aa8588f44772b34ca10485186dcaabd34d1";
+    rev = "roc-${version}";
     sha256 = "127cqvgzha54pr081fkhcfcwnfb6mwwmm4i8cmvf4jdmd24wci0a";
   };
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/rocm-opencl-driver/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-driver/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchFromGitHub, cmake, rocm-llvm, rocm-lld, rocm-clang-unwrapped }:
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "rocm-opencl-driver";
-  version = "1.9.0";
+  version = "1.9.1";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-OpenCL-Driver";
-    rev = "1f54475a50793971b4b35359ae837f2382285ddd";
+    rev = "roc-${version}";
     sha256 = "0wazvgdyy102c8j7zgblg3f28kwi24sf9fd4cyrpy1caz69294m7";
   };
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/rocm-opencl-runtime.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime.nix
@@ -15,14 +15,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.0";
+  version = "1.9.1";
   tag = "roc-${version}";
   name = "rocm-opencl-runtime-${version}";
   srcs =
     [ (fetchFromGitHub {
         owner = "RadeonOpenCompute";
         repo = "ROCm-OpenCL-Runtime";
-        rev = "e567d64b63674baab4cb20ad63cbffe45cf11551";
+        rev = tag;
         sha256 = "1vrs1810w8xhh839agqvb153xlg78azfz3wvpdgr3g2ic7hfs7nv";
         name = "ROCm-OpenCL-Runtime-${tag}-src";
       })

--- a/pkgs/development/libraries/rocr/default.nix
+++ b/pkgs/development/libraries/rocr/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, elfutils, roct }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.0";
+  version = "1.9.1";
   name = "rocr-${version}";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
     rev = "roc-${version}";
-    sha256 = "05s6j58n11v0hnafrmr24gh1199ykwvmclmny4ypcc1r0hv9jhi5";
+    sha256 = "1xsv243rrasx2pqpy9zaaj37ljjxqfz3nnrn9qw5cn5c0yf8wjjp";
   };
 
   postUnpack = ''

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, cmake, ed, pkgconfig
+, libunwind, git, rocm-cmake, rocminfo, hcc, hip, rocr
+, doCheck ? false
+, gtest }:
+stdenv.mkDerivation rec {
+  name = "rocrand";
+  version = "2018-09-20";
+  src = fetchFromGitHub {
+    owner = "ROCmSoftwarePlatform";
+    repo = "rocRAND";
+    rev = "7278524ea37f449795fdafcd0bf5307f61f06ba9";
+    sha256 = "1xnrk1wjcsykhshfdgqfbnm55lf7gv6sniya0fc2gysc4mda7057";
+  };
+  nativeBuildInputs = [ cmake ed git rocm-cmake pkgconfig ];
+  buildInputs = [ hcc hip rocminfo libunwind rocr ]
+    ++ stdenv.lib.optionals doCheck [ gtest ];
+
+  # We first move the `project` command to before we `include` another
+  # cmake file that looks for libraries. Then, cmake runs into
+  # problems if including hcc and hip config files as they have
+  # unguarded add_library calls, so we define HSA_HEADER and
+  # HSA_LIBRARY ourselves.
+#    printf '%s\n' 15m20 20-m15- w q | ed -s CMakeLists.txt
+  # preConfigure = ''
+  #   sed '/include(cmake\/SetToolchain.cmake)/d' -i CMakeLists.txt
+  #   sed 's,project(rocRAND CXX),project(rocRAND CXX)\ninclude(cmake/SetToolchain.cmake),' -i CMakeLists.txt
+  #   sed -e '/^[[:space:]]*find_package(hcc REQUIRED CONFIG PATHS .*$/ d' \
+  #       -e '/^[[:space:]]*find_package(hip REQUIRED CONFIG PATHS .*$/ d' \
+  #       -i cmake/Dependencies.cmake
+  # '';
+  cmakeFlags = [
+    "-DHSA_HEADER=${rocr}/include"
+    "-DHSA_LIBRARY=${rocr}/lib/libhsa-runtime64.so"
+    "-DHIP_PLATFORM=hcc"
+    "-DHIP_PATH=${hip}"
+    "-DCMAKE_CXX_COMPILER=${hcc}/bin/hcc"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ] ++ (let flag = if doCheck then "ON" else "OFF";
+        in [ "-DBUILD_TEST=${flag} -DBUILD_BENCHMARK=${flag}" ]);
+  postInstall = ''
+    mkdir -p $out/include $out/lib
+    cp -rs $out/hiprand/include/* $out/include
+    cp -rs $out/rocrand/include/* $out/include
+    cp -rs $out/hiprand/lib/* $out/lib
+    cp -rs $out/rocrand/lib/* $out/lib
+  '';
+}

--- a/pkgs/development/libraries/rocrand/python.nix
+++ b/pkgs/development/libraries/rocrand/python.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage, numpy, rocr, hip, rocrand }:
+{
+  rocrand-python = buildPythonPackage {
+    pname = "rocrand-python";
+    version = rocrand.version;
+    buildInputs = [ numpy ];
+    src = rocrand.src + /python/rocrand;
+    doCheck = false;
+    patchPhase = ''
+      sed -e 's|os.getenv("ROCRAND_PATH")|"${rocrand}/rocrand"|' \
+          -i rocrand/rocrand.py
+      sed -e 's|os.getenv("ROCM_PATH")|"${rocr}"|' \
+          -e 's|os.getenv("HIP_PATH")|"${hip}"|' \
+          -i rocrand/hip.py
+    '';
+  };
+  hiprand-python = buildPythonPackage {
+    pname = "hiprand-python";
+    version = rocrand.version;
+    buildInputs = [ numpy ];
+    src = rocrand.src + /python/hiprand;
+    doCheck = false;
+    patchPhase = ''
+      sed -e 's|os.getenv("HIPRAND_PATH")|"${rocrand}/hiprand"|' \
+          -e 's|os.getenv("ROCRAND_PATH")|"${rocrand}/rocrand"|' \
+          -i hiprand/hiprand.py
+      sed -e 's|os.getenv("ROCM_PATH")|"${rocr}"|' \
+          -e 's|os.getenv("HIP_PATH")|"${hip}"|' \
+          -i hiprand/hip.py
+    '';
+  };
+}

--- a/pkgs/development/libraries/roct.nix
+++ b/pkgs/development/libraries/roct.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, pciutils, numactl }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.0";
+  version = "1.9.1";
   name = "roct";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";

--- a/pkgs/tools/rocm-smi/default.nix
+++ b/pkgs/tools/rocm-smi/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python3 }:
 stdenv.mkDerivation rec {
   name = "rocm-smi";
-  version = "1.9.0";
+  version = "1.9.1";
   tag = "roc-${version}";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";


### PR DESCRIPTION
This updates the main packages to ROCm-1.9.1, and adds several peripheral libraries:

- rocblas
- rocrand
- rccl
- rocfft
- MIOpen
- cxlactivitylogger

These are all current for the 1.9.1 release, though not all have 1.9.1 release tags.