### PR TITLE
hip: move patchPhase commands to postPatch

### DIFF
--- a/pkgs/development/compilers/hip/default.nix
+++ b/pkgs/development/compilers/hip/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   # - fix path to rocm_agent_enumerator
   # - fix hcc path
   # - fix hcc version parsing
-  patchPhase = ''
+  postPatch = ''
     for f in $(find bin -type f); do
       sed -e 's,#!/usr/bin/perl,#!${perl}/bin/perl,' \
           -e 's,#!/bin/bash,#!${stdenv.shell},' \


### PR DESCRIPTION
The hip derivation used patchPhase for fixing up paths. However, this
overrides the default patchPhase of stdenv. This makes it harder to
override the hip derivation with a `patches` attribute, since patches
won't be applied by patchPhase. This change moves the path fixups to
postPatch, so that patchPhase of stdenv can still be used.

---

Ps. our use case is adding extra patches to hip through an overlay.