### PR TITLE
rocm-opencl-runtime: pass rocm-cmake

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -101,8 +101,8 @@ with pkgs;
 
   rocm-opencl-runtime = callPackage ./development/libraries/rocm-opencl-runtime.nix {
     stdenv = pkgs.overrideCC stdenv self.rocm-clang;
-    inherit (self) roct rocm-clang rocm-clang-unwrapped rocm-device-libs;
-    inherit (self) rocm-lld rocm-llvm rocr;
+    inherit (self) roct rocm-clang rocm-clang-unwrapped rocm-cmake;
+    inherit (self) rocm-device-libs rocm-lld rocm-llvm rocr;
     comgr = self.rocm-ocl-comgr;
   };
   rocm-opencl-icd = callPackage ./development/libraries/rocm-opencl-icd.nix {


### PR DESCRIPTION
Otherwise, building `rocm-opencl-runtime` fails with:

```
anonymous function at /nix/store/m887aci07v2jcd7gdl5smyp4h5899x2s-source/pkgs/development/libraries/rocm-opencl-runtime.nix:1:1 called without required argument 'rocm-cmake'
```