### PR TITLE
hashcat: Fix OpenCL compile issue like darktable did

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -504,6 +504,14 @@ with pkgs;
     '';
   });
 
+  hashcat-rocm = pkgs.hashcat.overrideAttrs (old: {
+    preFixup = (old.preFixup or "") + ''
+      for f in $(find $out/share/hashcat/OpenCL -name '*.cl'); do
+        sed "s|#include \"\(.*\)\"|#include \"$out/share/hashcat/OpenCL/\1\"|g" -i "$f"
+      done
+    '';
+  });
+
   rocm-llvm-project-aomp = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "llvm-project";


### PR DESCRIPTION
Override `hashcat` package to fix following errors for hashcat 5.1.0 with ROCm 3.3:
```
$ hashcat -b
clBuildProgram(): CL_BUILD_PROGRAM_FAILURE

/run/user/<uid>/comgr-c0bec5/input/CompileSource:7:10: fatal error: cannot open file '/run/user/<uid>/comgr-c0bec5/input/inc_vendor.cl': No such file or directory
#include "inc_vendor.cl"
         ^
1 error generated.
Error: Failed to compile opencl source (from CL or HIP source to LLVM IR).
```