### PR TITLE
fixed rocBLAS test

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -353,6 +353,17 @@ with pkgs;
     inherit (python3Packages) python;
   };
 
+  rocblas-test = callPackage ./development/libraries/rocblas {
+    inherit (self) rocm-cmake hcc hcc-unwrapped rocr rocblas-tensile;
+    hip = self.hip;
+    clang = self.hcc-clang;
+    openmp = self.hcc-openmp;
+    comgr = self.amd-comgr;
+    llvm = pkgs.llvmPackages_7.llvm;
+    inherit (python3Packages) python;
+    doCheck = true;
+  };
+
   # MIOpen
 
   miopengemm = callPackage ./development/libraries/miopengemm {

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub, lib, config, cmake, pkgconfig, libunwind, python
 , rocr, hcc, hcc-unwrapped, hip, rocm-cmake, comgr, clang
-, llvm, openmp
+, llvm, openmp, makeWrapper
 , doCheck ? false
 # Tensile slows the build a lot, but can produce a faster rocBLAS
 , useTensile ? true, rocblas-tensile ? null
-, gfortran, liblapack, boost, gtest }:
+, gfortran, liblapack, boost, gtest, openblas }:
 let pyenv = python.withPackages (ps:
                with ps; [pyyaml pip wheel setuptools virtualenv]); in
 assert useTensile -> rocblas-tensile != null;
@@ -17,10 +17,13 @@ stdenv.mkDerivation rec {
     rev = "rocm-${version}";
     sha256 = "1rjwx14zq9b31n58fdfarw2ray0i51vmawvl15ciiggpk24w2gfz";
   };
+
+  inherit doCheck;
+
   nativeBuildInputs = [ cmake rocm-cmake pkgconfig python ];
 
   buildInputs = [ libunwind pyenv hip rocr comgr llvm openmp hcc ]
-                ++ stdenv.lib.optionals doCheck [ gfortran boost gtest liblapack ];
+                ++ stdenv.lib.optionals doCheck [ gfortran boost gtest liblapack openblas makeWrapper ];
 
   CXXFLAGS = "-D__HIP_PLATFORM_HCC__";
   cmakeFlags = [
@@ -30,9 +33,10 @@ stdenv.mkDerivation rec {
     "-DBUILD_WITH_TENSILE=${if useTensile then "ON" else "OFF"}"
     ''-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}''
   ] ++ stdenv.lib.optionals doCheck [
-    "-DBUILD_CLIENTS_SAMPLES=YES"
+    "-DBUILD_CLIENTS_SAMPLES=NO"
     "-DBUILD_CLIENTS_TESTS=YES"
-    "-DBUILD_CLIENTS_BENCHMARKS=YES"
+    "-DBUILD_CLIENTS_BENCHMARKS=NO"
+    "-DLINK_BLIS=NO"
   ] ++ stdenv.lib.optionals useTensile [
     "-DVIRTUALENV_HOME_DIR=${rocblas-tensile}"
     "-DTensile_TEST_LOCAL_PATH=${rocblas-tensile}"
@@ -48,5 +52,32 @@ stdenv.mkDerivation rec {
         -e '/list( APPEND CMAKE_PREFIX_PATH \/opt\/rocm\/hcc \/opt\/rocm\/hip )/d' \
         -i CMakeLists.txt
     sed '/add_custom_command(/,/^ )/d' -i library/src/CMakeLists.txt
+
+    substituteInPlace ./clients/benchmarks/CMakeLists.txt \
+        --replace 'cblas lapack roc::rocblas' 'blas cblas lapack roc::rocblas'
+
+    substituteInPlace ./clients/gtest/CMakeLists.txt \
+        --replace 'cblas lapack roc::rocblas' 'blas cblas lapack roc::rocblas'
+
+    patchShebangs ./clients/common/rocblas_gentest.py
+  '';
+
+  preBuild = stdenv.lib.optional doCheck ''
+    cp -r ../clients/gtest/ clients/
+  '';
+
+  # not used, because GPU is not available during building
+  #checkPhase = ''
+  #  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/library/src/"
+  #  clients/staging/rocblas-test
+  #'';
+
+  postInstall = stdenv.lib.optional doCheck ''
+    mkdir -p $out/bin/
+    mkdir -p $out/test/
+    cp clients/staging/rocblas-test $out/bin/
+    cp clients/staging/rocblas_gtest.data $out/test/
+
+    wrapProgram $out/bin/rocblas-test --add-flags "--data $out/test/rocblas_gtest.data"
   '';
 }


### PR DESCRIPTION
Note: rocBLAS is currently broken (I suspect this is the reason for tensorflow failing) and segfaults immediately. This derivation was tested successfully on rocm 3.1.1 (f35af355c7a6388928d01b1a6a9513579dedc1d1).

This allows to build rocBLAS test. I disabled the benchmark-tool and the samples, since they don't belong to the test-suite.
It adds `rocblas-test`, which enables doCheck. This entry in all-packages.nix can also be removed.

The tests need to be run manually since a GPU is needed to run this test and it can't be found from inside the sandbox. The test-binary+data is added to the output when building with doCheck=true (it is false by default), this leads to an additional 650MB, so it only makes sense for testing. I choose to not create a new deviation, since I didn't find a way to build the test standalone (there might be one, but it is not obvious).
The test-binary is wrapped and can be called from the result-directory created by nix-build. (Be aware the test take a long time >6h for me).