### PR TITLE
rocm-device-libs: cleanup

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -37,9 +37,6 @@ with pkgs;
   rocm-device-libs = callPackage ./development/libraries/rocm-device-libs {
     inherit (self) rocm-runtime;
     inherit (self.llvmPackages_rocm) clang clang-unwrapped lld llvm;
-    stdenv = pkgs.overrideCC stdenv self.llvmPackages_rocm.clang;
-    tagPrefix = "rocm-ocl";
-    sha256 = "0h4aggj2766gm3grz387nbw3bn0l461walgkzmmly9a5shfc36ah";
   };
 
   rocm-comgr = callPackage ./development/libraries/comgr {
@@ -79,9 +76,8 @@ with pkgs;
 
   # A HIP compiler that does not go through hcc
   hip-clang = callPackage ./development/compilers/hip-clang {
-    inherit (self) rocm-thunk rocm-runtime rocminfo rocclr;
+    inherit (self) rocm-device-libs rocm-thunk rocm-runtime rocminfo rocclr;
     inherit (self.llvmPackages_rocm) clang clang-unwrapped llvm;
-    device-libs = self.rocm-device-libs;
     comgr = self.rocm-comgr;
   };
 

--- a/pkgs/development/compilers/hip-clang/default.nix
+++ b/pkgs/development/compilers/hip-clang/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, cmake, perl, python, writeText
 , file, binutils-unwrapped
 , llvm, clang, clang-unwrapped, lld
-, device-libs, rocm-thunk, rocm-runtime, rocminfo, comgr, rocclr
+, rocm-device-libs, rocm-thunk, rocm-runtime, rocminfo, comgr, rocclr
 }:
 stdenv.mkDerivation rec {
   name = "hip";
@@ -13,11 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "1xhw9sy9gln5mai8w8mrbiz1ik8m0lnk5g4p2gwa4f3mv96adlhd";
   };
   nativeBuildInputs = [ cmake python ];
-  propagatedBuildInputs = [ llvm clang lld rocm-thunk rocminfo device-libs rocm-runtime comgr rocclr ];
+  propagatedBuildInputs = [ llvm clang lld rocm-thunk rocminfo rocm-device-libs rocm-runtime comgr rocclr ];
 
   preConfigure = ''
     export HIP_CLANG_PATH=${clang}/bin
-    export DEVICE_LIB_PATH=${device-libs}/lib
+    export DEVICE_LIB_PATH=${rocm-device-libs}/lib
   '';
 
   # The patch version is the last two digits of year + week number +
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     sed -e 's,$ROCM_AGENT_ENUM = "''${ROCM_PATH}/bin/rocm_agent_enumerator";,$ROCM_AGENT_ENUM = "${rocminfo}/bin/rocm_agent_enumerator";,' \
         -e "s,^\($HIP_LIB_PATH=\).*$,\1\"$out/lib\";," \
         -e 's,^\($HIP_CLANG_PATH=\).*$,\1"${clang}/bin";,' \
-        -e 's,^\($DEVICE_LIB_PATH=\).*$,\1"${device-libs}/lib";,' \
+        -e 's,^\($DEVICE_LIB_PATH=\).*$,\1"${rocm-device-libs}/lib";,' \
         -e 's,^\($HIP_COMPILER=\).*$,\1"clang";,' \
         -e 's,^\($HIP_RUNTIME=\).*$,\1"ROCclr";,' \
         -e 's,^\([[:space:]]*$HSA_PATH=\).*$,\1"${rocm-runtime}";,'g \
@@ -117,7 +117,7 @@ stdenv.mkDerivation rec {
     mv $out/lib/cmake $out/share/
     mv $out/cmake/* $out/share/cmake/hip
     mkdir -p $out/lib
-    ln -s ${device-libs}/lib $out/lib/bitcode
+    ln -s ${rocm-device-libs}/lib $out/lib/bitcode
     mkdir -p $out/include
     ln -s ${clang-unwrapped}/lib/clang/11.0.0/include $out/include/clang
     ln -s ${rocclr}/lib/*.* $out/lib

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -1,23 +1,41 @@
-{ stdenv, fetchFromGitHub, runCommand, cmake
-, llvm, lld, clang, clang-unwrapped, rocm-runtime
-, source ? null
-, tagPrefix ? null
-, sha256 ? null }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, clang
+, clang-unwrapped
+, lld
+, llvm
+, rocm-runtime
+}:
+
 stdenv.mkDerivation rec {
-  name = "rocm-device-libs";
+  pname = "rocm-device-libs";
   version = "3.5.0";
+
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-Device-Libs";
     rev = "rocm-${version}";
     sha256 = "0n160jwbh7jnqckz5bn979ll8afh2a97lf962xh9xv3cx025vnrn";
   };
+
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvm lld clang rocm-runtime ];
+
+  buildInputs = [ clang lld llvm rocm-runtime ];
+
   cmakeBuildType = "Release";
+
   cmakeFlags = [
     "-DCMAKE_PREFIX_PATH=${llvm}/lib/cmake/llvm;${clang-unwrapped}/lib/cmake/clang"
     "-DLLVM_TARGETS_TO_BUILD='AMDGPU;X86'"
     "-DCLANG=${clang}/bin/clang"
   ];
+
+  meta = with stdenv.lib; {
+    description = "Set of AMD-specific device-side language runtime libraries";
+    homepage = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs";
+    license = licenses.ncsa;
+    maintainers = with maintainers; [ acowley danieldk ];
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
I have removed the stdenv override. We don't use it in nixpkgs and so far it does not seem necessary. Is therethere a downstream dependency that requires that `rocm-device-libs` is compiled with clang?