### PR TITLE
Bump to rocm-5.1.3

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/clang.nix
+++ b/pkgs/development/compilers/llvm/rocm/clang.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, fetchFromGitHub
 , cmake
 , python3
 , llvm
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DLLVM_CMAKE_PATH=${llvm}/lib/cmake/llvm"
-    "-DLLVM_MAIN_SRC_DIR=${llvm.src}"
+    "-DLLVM_MAIN_SRC_DIR=${llvm.src}/llvm"
     "-DCLANG_SOURCE_DIR=${src}"
     "-DLLVM_ENABLE_RTTI=ON"
   ];

--- a/pkgs/development/compilers/llvm/rocm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, callPackage, wrapCCWith, overrideCC }:
 
 let
-  version = "5.0.2";
+  version = "5.1.3";
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "llvm-project";
     rev = "rocm-${version}";
-    hash = "sha256-wPzwbeQUFE6RAytrz5lBa6UUPoVL0UeMyY3qa4M6W6M=";
+    hash = "sha256-5SGIWiyfHvfwIUc4bhdWrlhBfK5ssA7tm5r3zKdr3kg=";
   };
 in rec {
   clang = wrapCCWith rec {
@@ -52,7 +52,7 @@ in rec {
 
   llvm = callPackage ./llvm.nix {
     inherit version;
-    src = "${src}/llvm";
+    src = "${src}";
   };
 
   compiler-rt = callPackage ./compiler-rt {

--- a/pkgs/development/compilers/llvm/rocm/lld.nix
+++ b/pkgs/development/compilers/llvm/rocm/lld.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  cmakeFlags = [ "-DLLVM_MAIN_SRC_DIR=${llvm.src}" ];
+  cmakeFlags = [ "-DLLVM_MAIN_SRC_DIR=${llvm.src}/llvm" ];
 
   postInstall = ''
     moveToOutput include "$dev"

--- a/pkgs/development/compilers/llvm/rocm/llvm.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-, fetchFromGitHub
 , cmake
 , python3
 , libxml2
@@ -56,6 +55,10 @@ in stdenv.mkDerivation rec {
     "-DSPHINX_OUTPUT_HTML=OFF"
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
   ];
+
+  prePatch = ''
+    cd llvm
+  '';
 
   postPatch = ''
     substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib

--- a/pkgs/development/libraries/rocclr/default.nix
+++ b/pkgs/development/libraries/rocclr/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocclr";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "ROCm-Developer-Tools";
     repo = "ROCclr";
     rev = "rocm-${version}";
-    hash = "sha256-x6XwYxgiCoy6Q7gIevSTEWgUQ0aEjPFhKSqMqQahHig=";
+    hash = "sha256-WWF/IrPPM0n9FLjyw8veOWJWXqptMb1NKDrI9O/PLnQ=";
   };
 
   nativeBuildInputs = [ cmake rocm-cmake ];

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-comgr";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-CompilerSupport";
     rev = "rocm-${version}";
-    hash = "sha256-EIBH7TXelo6mr+/vJ+iT+VLUVoQqWmNsgeN3Nwwr+tM=";
+    hash = "sha256-zlCM3Zue7MEhL1c0gUPwRNgdjzyyF9BEP3UxE8RYkKk=";
   };
 
   sourceRoot = "source/lib/comgr";

--- a/pkgs/development/libraries/rocm-device-libs/default.nix
+++ b/pkgs/development/libraries/rocm-device-libs/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-device-libs";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-Device-Libs";
     rev = "rocm-${version}";
-    hash = "sha256-eZdy9+BfuUVzPO6huvqcwCog96qMVTYoY3l6J0YMUZQ=";
+    hash = "sha256-kmCk+BpM1QCJzEAkru2LK3CGwVXNUEZBFicmwnrPcx8=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/rocm-opencl-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-opencl-runtime/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-opencl-runtime";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCm-OpenCL-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-ovYwElZGRKySH1mWFIISxuNNxCjaqoe9oCvqYZGdfq0=";
+    hash = "sha256-O7q3uTjspO/rZ2+8+g7pRfBXsCRaEr4DZxEqABHbOeY=";
   };
 
   nativeBuildInputs = [ cmake rocm-cmake ];

--- a/pkgs/development/libraries/rocm-runtime/default.nix
+++ b/pkgs/development/libraries/rocm-runtime/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-runtime";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCR-Runtime";
     rev = "rocm-${version}";
-    hash = "sha256-KOzVZNHtpwEOn7lZ36c4BGrImrq8dkUWRiHqGm+UTDk=";
+    hash = "sha256-Z8O5ToPWG9VsH+ANGv3ktpNuaic5ViC8fvSOwInxLMg=";
   };
 
   sourceRoot = "source/src";

--- a/pkgs/development/libraries/rocm-thunk/default.nix
+++ b/pkgs/development/libraries/rocm-thunk/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-thunk";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "ROCT-Thunk-Interface";
     rev = "rocm-${version}";
-    hash = "sha256-hhDLy92jS/akp1Ozun45OEjVbVcjufkRIfC8bqqFjp4=";
+    hash = "sha256-Qvbvfe1fhoLTkDnzG0WzfAxbyDoEJwkzVvlBGTBkq0w=";
   };
 
   preConfigure = ''

--- a/pkgs/development/tools/build-managers/rocm-cmake/default.nix
+++ b/pkgs/development/tools/build-managers/rocm-cmake/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-cmake";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocm-cmake";
     rev = "rocm-${version}";
-    hash = "sha256-4PtLe864MQ9wUn+l1fshiiTQvP06ewD39TDYZl70Hgg=";
+    hash = "sha256-7jLn0FIjsww1lu1J9MB0s/Ksnw66BL1U0jQwiwmgw64=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/system/rocm-smi/default.nix
+++ b/pkgs/tools/system/rocm-smi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rocm-smi";
-  version = "5.0.2";
+  version = "5.1.3";
 
   src = fetchFromGitHub {
     owner = "RadeonOpenCompute";
     repo = "rocm_smi_lib";
     rev = "rocm-${version}";
-    hash = "sha256-SQ6eBQzZ8CBD9RlIjt25FrOuWUSybBzx6ZzCOzHbxdI=";
+    hash = "sha256-11o4xUyeQ3W/RPY62r8ahwcljKh/rkVSyTk5ruTU66U=";
   };
 
   nativeBuildInputs = [ cmake python3.pkgs.wrapPython ];


### PR DESCRIPTION
## To do

 * [ ] Fix the `rocclr` build. It [appears](https://github.com/ROCm-Developer-Tools/ROCclr/blob/rocm-5.1.x/CMakeLists.txt#L26) that you are no longer supposed to build `rocclr` independently but rather do so as part of some other component. However, the documentation is quite silent on this matter and it's quite unclear what other source of truth is available for build procedures.

## Notes

The ROCM `llvm` build now depends upon `ThirdParty/benchmark` in the source tree
root. Consequently, we now use the entire source tree as `src` of
the `llvm` derivation.